### PR TITLE
Working with Ubuntu 20.04/ROS Noetic, more robust error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Also, the serial port may not have correct privileges. Try the following, after 
 sudo chmod a+rw /dev/ttyUSB0 
 ```
 
+
+Make sure the device is set to a consistent path (e.g.) with udev rules. Otherwise the device may be set to a different path if it is disconnected and reconnected. It may be necessary to specify the device serial number in this rule because it uses a generic UART bridge.
+
 ## ROS API
 
 ## Nodes
@@ -39,43 +42,24 @@ sudo chmod a+rw /dev/ttyUSB0
 
 `~/multirae/CI2` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
 
-- The current CI2 reading.
-
 `~/multirae/CO` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
-
-- The current CO reading.
 
 `~/multirae/CO2` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
 
-- The current CO2 reading.
-
 `~/multirae/HCN` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
-
-- The current HCN reading.
 
 `~/multirae/H2S` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
 
-- The current H2S reading.
-
 `~/multirae/LEL` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
-
-- The current LEL reading.
 
 `~/multirae/NH3` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
 
-- The current NH3 reading.
-
 `~/multirae/OXY` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
-
-- The current OXY reading.
 
 `~/multirae/SO2` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
 
-- The current SO2 reading.
-
 `~/multirae/VOC` ([std\_msgs/Float32](http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float32.html))
 
-- The current VOC reading.
 #### Subscribed Topics
 
 - None
@@ -88,7 +72,9 @@ sudo chmod a+rw /dev/ttyUSB0
 
 `~/multirae/usb_port` (`String`, default: "/dev/ttyUSB1")
 
-- USB port to interface with sensor.
+`~/multirae/baud_rate` (`Int`, default: 9600)
+
+`~/multirae/poll_rate` (`Int`, default: 1)
 
 MultiRAE<sup>1</sup> https://sps.honeywell.com/us/en/products/safety/gas-and-flame-detection/portables/multirae
 
@@ -121,7 +107,3 @@ MultiRAE<sup>1</sup> https://sps.honeywell.com/us/en/products/safety/gas-and-fla
 
 6. To flash with the P2P functionality, you'll need to purchase the MultiRAE upgrade kit "SAS-0003-000" which includes the M01-0309-000 travel charger needed for RS232 serial communication.  THe "regular" travel charger M01-3021-000 is USB only and cannot be used for P2P functionality.  Follow the procedure in P2P process.docx to flash with P2P serial upgrade
 
-
-
-
-        

--- a/config/multirae.yaml
+++ b/config/multirae.yaml
@@ -1,0 +1,3 @@
+usb_port: "/dev/ttyUSB0"
+baud_rate: 9600
+poll_rate: 1

--- a/launch/multirae.launch
+++ b/launch/multirae.launch
@@ -2,8 +2,9 @@
 <launch>
   
   <!-- Multirae driver-->
-  <param name="multirae/usb_port" value="/dev/ttyUSB0"/>
-  <param name="multirae/baudrate" value="9600"/>
-  <node pkg="multirae" type="multirae_node" name="multirae_driver" output="screen"/>
+  <group ns="multirae">
+    <rosparam file="$(find multirae)/config/multirae.yaml" />
+    <node pkg="multirae" type="multirae_node" name="multirae_driver" respawn="true" output="screen"/>
+  </group>
 
 </launch>

--- a/src/multirae_node.cpp
+++ b/src/multirae_node.cpp
@@ -119,7 +119,7 @@ int main( int argc, char* argv[]) {
   while (ros::ok()){
     write(serial_port, &msg, 1);                                               // Send 'r' to refresh data
     Timeout.tv_usec = ((1.0/poll_rate)*1000000);                               // reset timeout
-    if(select(serial_port+1, &read_fds, NULL, NULL, &Timeout) == 1){           // Wat a max period of 'timeout' for a line to become available
+    if(select(serial_port+1, &read_fds, NULL, NULL, &Timeout) == 1){           // Wait a max period of 'timeout' for a line to become available
       read(serial_port, &read_buf, 1);                                         // The multirae helpfully null-terminates its strings, but in canonical mode we don't want those because \n marks the end of transmission
       bytes_read = read(serial_port, &read_buf, sizeof(read_buf));             // Read in the line of sensor data
     }

--- a/src/multirae_node.cpp
+++ b/src/multirae_node.cpp
@@ -120,7 +120,7 @@ int main( int argc, char* argv[]) {
     write(serial_port, &msg, 1);                                               // Send 'r' to refresh data
     Timeout.tv_usec = ((1.0/poll_rate)*1000000);                               // reset timeout
     if(select(serial_port+1, &read_fds, NULL, NULL, &Timeout) == 1){           // Wat a max period of 'timeout' for a line to become available
-      read(serial_port, NULL, 1);                                              // The multirae helpfully null-terminates its strings, but in canonical mode we don't want those because \n marks the end of transmission
+      read(serial_port, &read_buf, 1);                                         // The multirae helpfully null-terminates its strings, but in canonical mode we don't want those because \n marks the end of transmission
       bytes_read = read(serial_port, &read_buf, sizeof(read_buf));             // Read in the line of sensor data
     }
     else


### PR DESCRIPTION
The upgrade to Ubuntu 20.04 and ROS Noetic caused this driver to stop working. While troubleshooting I decided it would be easier to rewrite the whole thing. The resulting code is over 50% smaller (in lines of code). In addition to fixing the main issue of Noetic compatibility I added refresh rate as a ROS parameter and made the program much more robust to errors. If the device loses connection, the driver will wait and resume publishing when it is reconnected.

I did some basic performance testing as well. The new program is moderately faster although it uses a few extra KB of memory.

[multirae_driver_performance_test.txt](https://github.com/TyHowellWork/multirae/files/9841906/multirae_driver_performance_test.txt)
